### PR TITLE
Add workaround for duplicate key error

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -69,9 +69,13 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             builder.logLevel(Analytics.LogLevel.VERBOSE)
         }
 
-        Analytics.setSingletonInstance(
-            RNAnalytics.buildWithIntegrations(builder)
-        )
+        try {
+            Analytics.setSingletonInstance(
+                RNAnalytics.buildWithIntegrations(builder)
+            )
+        } catch(e: Expcetion) {
+            // Most likely already set up during development
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
When reloading a RN application on Android with this package installed
you will get an error that the module is already set up. To hinder this
we do a very simple try catch and ignore any errors.